### PR TITLE
[PLA-1976] Fixes BitArray decoding

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   shelf: ^1.4.2
   shelf_plus: ^1.9.2
   polkadart: ^0.4.7
-  substrate_metadata: ^1.2.1
+  substrate_metadata: ^1.2.2
   polkadart_scale_codec: ^1.2.1
   compute: ^1.0.2
 


### PR DESCRIPTION
### **PR Type**
dependencies


___

### **Description**
- Updated the `substrate_metadata` dependency version in `pubspec.yaml` from `^1.2.1` to `^1.2.2`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pubspec.yaml</strong><dd><code>Update `substrate_metadata` dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pubspec.yaml

<li>Updated the <code>substrate_metadata</code> dependency version from <code>^1.2.1</code> to <br><code>^1.2.2</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-decoder/pull/37/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

